### PR TITLE
added ability to change weapon slots with dominant joystick X axis 

### DIFF
--- a/Projects/Android/jni/src/Lambda1VR/VrInputAlt.c
+++ b/Projects/Android/jni/src/Lambda1VR/VrInputAlt.c
@@ -281,6 +281,13 @@ void HandleInput_Alt( ovrInputStateTrackedRemote *pDominantTrackedRemoteNew, ovr
 					firingPrimary = (pDominantTrackedRemoteNew->Buttons & ovrButton_Trigger);
 					sendButtonAction("+attack", firingPrimary);
 				}
+				// we need to release secondary fire if dominantGripPushed has been released before releasing trigger -> should fix the gun jamming and non stop firing secondary attack bug
+				if ((pDominantTrackedRemoteNew->Buttons & ovrButton_Trigger) !=
+					(pDominantTrackedRemoteOld->Buttons & ovrButton_Trigger) &&
+					(pDominantTrackedRemoteNew->Buttons & ovrButton_Trigger) == false)
+				{
+					sendButtonAction("+attack2", false);
+				}
 			}
 
 			//Duck

--- a/Projects/Android/jni/src/Lambda1VR/VrInputDefault.c
+++ b/Projects/Android/jni/src/Lambda1VR/VrInputDefault.c
@@ -305,23 +305,62 @@ void HandleInput_Default( ovrInputStateTrackedRemote *pDominantTrackedRemoteNew,
 
 			//Weapon Chooser
 			static bool weaponSwitched = false;
-			if (between(-0.25f, pDominantTrackedRemoteNew->Joystick.x, 0.25f) &&
-				(between(0.75f, pDominantTrackedRemoteNew->Joystick.y, 1.0f) ||
-				 between(-1.0f, pDominantTrackedRemoteNew->Joystick.y, -0.75f)))
+			if (vr_snapturn_angle->value != 0) // if snap angle feature is enabled
 			{
-				if (!weaponSwitched) {
-					if (between(0.75f, pDominantTrackedRemoteNew->Joystick.y, 1.0f))
-					{
-						sendButtonActionSimple("invnext");
+				if (between(-0.25f, pDominantTrackedRemoteNew->Joystick.x, 0.25f) &&
+					(between(0.75f, pDominantTrackedRemoteNew->Joystick.y, 1.0f) ||
+						between(-1.0f, pDominantTrackedRemoteNew->Joystick.y, -0.75f)))
+				{
+					if (!weaponSwitched) {
+						if (between(0.75f, pDominantTrackedRemoteNew->Joystick.y, 1.0f))
+						{
+							sendButtonActionSimple("invnext");
+						}
+						else
+						{
+							sendButtonActionSimple("invprev");
+						}
+						weaponSwitched = true;
 					}
-					else
-					{
-						sendButtonActionSimple("invprev");
-					}
-					weaponSwitched = true;
 				}
-			} else {
-				weaponSwitched = false;
+				else {
+					weaponSwitched = false;
+				}
+			}
+			else // allow slot selection (columns of weapon hud)
+			{
+				if (between(0.75f, pDominantTrackedRemoteNew->Joystick.y, 1.0f) ||
+					between(-1.0f, pDominantTrackedRemoteNew->Joystick.y, -0.75f) ||
+					between(0.75f, pDominantTrackedRemoteNew->Joystick.x, 1.0f) ||
+					between(-1.0f, pDominantTrackedRemoteNew->Joystick.x, -0.75f))
+				{
+					if (!weaponSwitched) {
+						if (!weaponSwitched)
+						{
+							if (between(0.75f, pDominantTrackedRemoteNew->Joystick.y, 1.0f))
+							{
+								sendButtonActionSimple("invprev"); // in this mode is makes more sense to select the next item with Joystick down; this is the mouse wheel behaviour in hl
+							}
+							else if (between(-1.0f, pDominantTrackedRemoteNew->Joystick.y, -0.75f))
+							{
+								sendButtonActionSimple("invpnext");
+							}
+							else if (between(0.75f, pDominantTrackedRemoteNew->Joystick.x, 1.0f))
+							{
+								sendButtonActionSimple("invnextslot"); // not an original hl methode -> needs update from hlsdk-xash3d
+							}
+							else if (between(-1.0f, pDominantTrackedRemoteNew->Joystick.x, -0.75f))
+							{
+								sendButtonActionSimple("invprevslot");
+							}
+							weaponSwitched = true;
+						}
+						weaponSwitched = true;
+					}
+				}
+				else {
+					weaponSwitched = false;
+				}
 			}
 		}
 

--- a/Projects/Android/jni/src/Lambda1VR/VrInputDefault.c
+++ b/Projects/Android/jni/src/Lambda1VR/VrInputDefault.c
@@ -293,6 +293,13 @@ void HandleInput_Default( ovrInputStateTrackedRemote *pDominantTrackedRemoteNew,
 					firingPrimary = (pDominantTrackedRemoteNew->Buttons & ovrButton_Trigger);
 					sendButtonAction("+attack", firingPrimary);
 				}
+				// we need to release secondary fire if dominantGripPushed has been released before releasing trigger -> should fix the gun jamming and non stop firing secondary attack bug
+				if ((pDominantTrackedRemoteNew->Buttons & ovrButton_Trigger) !=
+					(pDominantTrackedRemoteOld->Buttons & ovrButton_Trigger) &&
+					(pDominantTrackedRemoteNew->Buttons& ovrButton_Trigger) == false)
+				{
+					sendButtonAction("+attack2", false);
+				}
 			}
 
 			//Duck

--- a/Projects/Android/jni/src/Lambda1VR/VrInputDefault.c
+++ b/Projects/Android/jni/src/Lambda1VR/VrInputDefault.c
@@ -343,7 +343,7 @@ void HandleInput_Default( ovrInputStateTrackedRemote *pDominantTrackedRemoteNew,
 							}
 							else if (between(-1.0f, pDominantTrackedRemoteNew->Joystick.y, -0.75f))
 							{
-								sendButtonActionSimple("invpnext");
+								sendButtonActionSimple("invnext");
 							}
 							else if (between(0.75f, pDominantTrackedRemoteNew->Joystick.x, 1.0f))
 							{

--- a/Projects/Android/jni/src/Lambda1VR/VrInputLeftAlt2.c
+++ b/Projects/Android/jni/src/Lambda1VR/VrInputLeftAlt2.c
@@ -169,7 +169,7 @@ void HandleInput_LeftAlt2()
 				finishReloadNextFrame = false;
 			}
 
-			if (pDominantTracking->Status & VRAPI_TRACKING_STATUS_POSITION_TRACKED) {
+			if (leftRemoteTracking_new.Status & VRAPI_TRACKING_STATUS_POSITION_TRACKED) {
 				canUseBackpack = false;
 			}
 			else if (!canUseBackpack && grabMeleeWeapon == 0) {
@@ -286,9 +286,9 @@ void HandleInput_LeftAlt2()
 					sendButtonAction("+attack", firingPrimary);
 				}
 				// we need to release secondary fire if dominantGripPushed has been released before releasing trigger -> should fix the gun jamming and non stop firing secondary attack bug
-				if ((pDominantTrackedRemoteNew->Buttons & ovrButton_Trigger) !=
-					(pDominantTrackedRemoteOld->Buttons & ovrButton_Trigger) &&
-					(pDominantTrackedRemoteNew->Buttons & ovrButton_Trigger) == false)
+				if ((leftTrackedRemoteState_new.Buttons & ovrButton_Trigger) !=
+					(leftTrackedRemoteState_old.Buttons & ovrButton_Trigger) &&
+					(leftTrackedRemoteState_new.Buttons & ovrButton_Trigger) == false)
 				{
 					sendButtonAction("+attack2", false);
 				}

--- a/Projects/Android/jni/src/Lambda1VR/VrInputLeftAlt2.c
+++ b/Projects/Android/jni/src/Lambda1VR/VrInputLeftAlt2.c
@@ -36,6 +36,7 @@ void HandleInput_LeftAlt2()
 
 	static bool dominantGripPushed = false;
 	static int grabMeleeWeapon = 0;
+	static bool canUseBackpack = false;
 	static float dominantGripPushTime = 0.0f;
 
 	//Show screen view (if in multiplayer toggle scoreboard)
@@ -168,6 +169,15 @@ void HandleInput_LeftAlt2()
 				finishReloadNextFrame = false;
 			}
 
+			if (pDominantTracking->Status & VRAPI_TRACKING_STATUS_POSITION_TRACKED) {
+				canUseBackpack = false;
+			}
+			else if (!canUseBackpack && grabMeleeWeapon == 0) {
+				int channel = (vr_control_scheme->integer >= 10) ? 0 : 1;
+				Android_Vibrate(40, channel, 0.5); // vibrate to let user know they can switch
+				canUseBackpack = true;
+			}
+
 			if ((leftTrackedRemoteState_new.Buttons & ovrButton_GripTrigger) !=
 				(leftTrackedRemoteState_old.Buttons & ovrButton_GripTrigger)) {
 
@@ -274,6 +284,13 @@ void HandleInput_LeftAlt2()
 
 					firingPrimary = (leftTrackedRemoteState_new.Buttons & ovrButton_Trigger);
 					sendButtonAction("+attack", firingPrimary);
+				}
+				// we need to release secondary fire if dominantGripPushed has been released before releasing trigger -> should fix the gun jamming and non stop firing secondary attack bug
+				if ((pDominantTrackedRemoteNew->Buttons & ovrButton_Trigger) !=
+					(pDominantTrackedRemoteOld->Buttons & ovrButton_Trigger) &&
+					(pDominantTrackedRemoteNew->Buttons & ovrButton_Trigger) == false)
+				{
+					sendButtonAction("+attack2", false);
 				}
 			}
 


### PR DESCRIPTION
**NEEDS pull request to work: https://github.com/DrBeef/hlsdk-xash3d/pull/2**

added ability to change weapon slots with dominant joystick X axis and inverted Y axis to imitate mouse scroll wheel behavior
this is only used if vr_snapturn_angle->value == 0

This behavior makes it way easier to change weapons fast later in the game when you have a lot.
You change weapon category/slot with joy X and inside the category with joy Y 
this is very similar to how it worked on pc where you had specific keys for the weapon slots

the merge looks a bit odd but the original behavior is kept if  vr_snapturn_angle->value != 0
if you like the scheme I can also add it to the alternative scheme. The only conflicting thing would be right now that you can cycle trough weapons by repeatedly pressing Y. Is this intended? 